### PR TITLE
Após o login redirecionar para a URL correta

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -303,6 +303,10 @@ class ApplicationController < ActionController::Base
     login_path
   end
 
+  def after_sign_in_path_for(args)
+    session[:return_to] || root_path
+  end
+
   def record_activity(note, loggeable)
 #    if !ActivityRecord.where(user_id: current_user.id, site_id: current_site.id, controller: controller_name, action: action_name, loggeable: loggeable, 
       @activity = ActivityRecord.new
@@ -318,5 +322,4 @@ class ApplicationController < ActionController::Base
       @activity.save
 #    end
   end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@ class SessionsController < Devise::SessionsController
   layout 'weby_sessions'
 
   before_filter :set_domain
+  before_filter :store_location, only: :new
 
   private
 
@@ -11,5 +12,9 @@ class SessionsController < Devise::SessionsController
       current_domain = request.host.gsub(/www\./, '')
     end
     request.session_options[:domain] = ".#{current_domain}"
+  end
+
+  def store_location
+    session[:return_to] = params[:back_url]
   end
 end


### PR DESCRIPTION
Quando usávamos o authlogic, após o login o sistema redirecionava para a URL que vinha em params[:back_url], agora vai para root_url (padrão do devise).

A solução segue no caminho do método after_sign_in_path_for
