### PR TITLE
Atualizando gem acts_on_taggable e mudando helpers que criam informações do kaminari

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'kaminari', '0.14.1'
 gem 'paperclip', '3.5.1'
 gem 'acts_as_list', '0.1.9'
 gem 'simple_form', '2.1.1'
-gem 'acts-as-taggable-on', '3.0.1'
+gem 'acts-as-taggable-on', '3.2.3'
 gem 'bootstrap-sass', '3.1.1'
 gem 'foreigner'
 gem "select2-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,8 +52,9 @@ GEM
     activesupport (3.2.18)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    acts-as-taggable-on (3.0.1)
-      rails (>= 3, < 5)
+    acts-as-taggable-on (3.2.3)
+      actionpack (>= 3, < 5)
+      activerecord (>= 3, < 5)
     acts_as_list (0.1.9)
     arel (3.0.3)
     bcrypt (3.1.7)
@@ -248,7 +249,7 @@ PLATFORMS
 
 DEPENDENCIES
   acadufg!
-  acts-as-taggable-on (= 3.0.1)
+  acts-as-taggable-on (= 3.2.3)
   acts_as_list (= 0.1.9)
   better_errors
   binding_of_caller

--- a/app/controllers/sites/pages_controller.rb
+++ b/app/controllers/sites/pages_controller.rb
@@ -4,7 +4,7 @@ class Sites::PagesController < ApplicationController
 
   helper_method :sort_column
   before_filter :check_current_site
-  
+
   respond_to :html, :js, :json, :rss
 
   # GET /pages

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -225,10 +225,10 @@ module ApplicationHelper
   end
 
   # Pagination's informations
-  # TODO
-  # TODO
+  # TODO refatorar isso aqui, antes fazia collection.page(1).count mudei para
+  # collection.page(1).length para poder trabalhar com querys usando group
   def info_page(collection, style = nil)
-    if collection.page(1).count > 0
+    if collection.page(1).length > 0
       html = "#{t('views.pagination.displaying')} #{collection.offset_value + 1} -
       #{collection.offset_value + collection.length}"
       html << " #{t('of')} #{collection.total_count}"
@@ -239,7 +239,7 @@ module ApplicationHelper
 
   # Generate links in order to select the amount of intes per page
   def per_page_links(collection, remote = false, size = nil)
-    if collection.page(1).count > per_page_array.first.to_i
+    if collection.page(1).length > per_page_array.first.to_i
       html = "<li><span>#{t('views.pagination.per_page')} </span></li>"
 
       params[:per_page] = per_page_default if params[:per_page].blank?

--- a/db/migrate/20140522122835_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140522122835_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140402120348) do
+ActiveRecord::Schema.define(:version => 20140522122835) do
 
   create_table "activity_records", :force => true do |t|
     t.integer  "user_id"
@@ -377,7 +377,8 @@ ActiveRecord::Schema.define(:version => 20140402120348) do
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], :name => "taggings_idx", :unique => true
 
   create_table "tags", :force => true do |t|
-    t.string "name"
+    t.string  "name"
+    t.integer "taggings_count", :default => 0
   end
 
   add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true


### PR DESCRIPTION
Antes nos helpers que criamos pro `kaminari` usavamos `collection.count` porém se o `collection` for um `AREL` que tenha um `group` esse `count` quebra pois em vez de retornar um string retorna um hash, mudei pra `collection.length` que o comportamento fica correto. Foi necessário fazer isso porque quando se filtra por `tags` a gem que foi atualizada usa `group` na query.

e.g.

``` ruby
Page.group(:id).count
# => {1=>1, 2=>1}

Page.group(:id).length
# => 2

Page.count
# => 2
```
