### PR TITLE
Make end date to be inclusive

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,9 +1,10 @@
 $(document).ready(function() {
   var $calendar = $('#calendar');
   $calendar.fullCalendar({
-    height: 420,
+    height: 460,
     lang: $('html').attr('lang'),
     header: {left: 'today prev,next', center: 'title', right: 'month,basicWeek'},
+    nextDayThreshold: '00:00:00',
     events: {
       url: $calendar.data('url'),
       cache: true,

--- a/vendor/engines/calendar/app/assets/javascripts/calendar/events.index.js
+++ b/vendor/engines/calendar/app/assets/javascripts/calendar/events.index.js
@@ -3,6 +3,7 @@ $(document).ready(function() {
   $calendar.fullCalendar({
     lang: $('html').attr('lang'),
     header: {left: 'today prev,next', center: 'title', right: 'month,basicWeek'},
+    nextDayThreshold: '00:00:00',
     events: {
       url: $calendar.data('url'),
       cache: true,

--- a/vendor/engines/calendar/app/models/calendar/event.rb
+++ b/vendor/engines/calendar/app/models/calendar/event.rb
@@ -100,6 +100,7 @@ module Calendar
           end: event.end_at,
           url: admin_link ? helper.admin_event_path(event) : helper.event_path(event),
           color: '#3a87ad',
+          allDay: false,
           description: event.information
         }
       end


### PR DESCRIPTION
Caso de teste:
Criar um evento com 3 dias de duração. ex: 21 à 23 do mês atual (Sem setar as horas, deixe 00:00)
Verificar se no calendário a div do evento vai do dia 21 à 23 (em /events)